### PR TITLE
fix: install ca-certificates when building docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN \
     useradd --uid 10001 --gid 10001 --home /app --create-home app && \
     \
     apt-get -qq update && \
-    apt-get -qq install -y default-libmysqlclient-dev libssl-dev && \
+    apt-get -qq install -y default-libmysqlclient-dev libssl-dev ca-certificates && \
+    update-ca-certificates && \
     rm -rf /var/lib/apt/lists
 
 COPY --from=builder /app/bin /app/bin


### PR DESCRIPTION

When [using the published docker image in our fxa-dev setup](https://github.com/mozilla/fxa-dev/pull/384) we see a log of error messages logged like:

```
Jul 09 13:53:48.096 WARN Error: HttpDispatch(HttpDispatchError { message: "The OpenSSL library reported an error" }) Jul 09 13:58:48.250 WARN Error: HttpDispatch(HttpDispatchError { message: "The OpenSSL library reported an error" })
```

According to [this stackoverflow](https://stackoverflow.com/questions/44728421/docker-and-the-openssl-library-reported-an-error-when-deployed) the error is often caused by missing ca certs in the docker image, so I've shamelessly stolen some docker build logic from [the fxa-email-service](https://github.com/mozilla/fxa-email-service/commit/0e172a9c4877409f9577bb69d0cca1be45775ddb#diff-3254677a7917c6c01f55212f86c57fbfR29) and included it here.
