### PR TITLE
feat: hacky support of ROCKET_LOG=off

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ USER app
 
 # override rocket's dev env defaulting to localhost
 ENV ROCKET_ADDRESS 0.0.0.0
+ENV ROCKET_LOG off
 
 CMD ["/app/bin/pushbox"]


### PR DESCRIPTION
and default it in the Dockerfile

Closes #33 

Beatrice landed a PR for rocket 0.4 (rocket master) that enables a ROCKET_LOG=off. In an attempt to avoid rocket 0.4 I hacked this together