### PR TITLE
chore: fix the mysql port

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,9 +6,7 @@ services:
             - db_data:/var/lib/mysql
         restart: always
         ports:
-            - "4306:3306"
-            - "5567:5567"
-            - "5568:5568"
+            - "3306"
         environment:
             #MYSQL_RANDOM_ROOT_PASSWORD: yes
             MYSQL_ROOT_PASSWORD: random
@@ -18,12 +16,13 @@ services:
 
     app:
         build: .
+        restart: always
         ports:
           - "8000:8000"
         depends_on:
           - db
         environment:
-          ROCKET_DATABASE_URL: mysql://test:test@db:4306/pushbox
+          ROCKET_DATABASE_URL: mysql://test:test@db:3306/pushbox
 
 volumes:
     db_data:


### PR DESCRIPTION
service-to-service communications use the CONTAINER_PORT. disable
the mysql HOST_PORT which isn't needed

and restart: true the app container to handle startup hiccups
(e.g. mysql not running yet)

Closes #65